### PR TITLE
EL209 - Electorate suggestion 404 error

### DIFF
--- a/templates/constituencies.tpl
+++ b/templates/constituencies.tpl
@@ -6,7 +6,7 @@
             <label for="txtSearch">Postcode</label>
             <input type="text" id="txtSearch" name="p" />
             <input  type="submit" value="GO" />
-            <small>e.g. <a href="{$www_server}/{$area_names}?p={$example_postcode}">{$example_postcode}</a></small>
+            <small>e.g. <a href="{$www_server}/{$area_names}/?p={$example_postcode}">{$example_postcode}</a></small>
         </form>
         <div class="section">
             <ul>


### PR DESCRIPTION
If example search postcode selected, electorate links returned 404.
Results generated via form search were working fine.

Used same url structure for example as used in search form.
